### PR TITLE
Merge lobby settings and layout features

### DIFF
--- a/src/hanabi.css
+++ b/src/hanabi.css
@@ -35,6 +35,21 @@ button.abandon {
 	border: none;
 }
 
+#show-resources {
+	position: absolute;
+	right: 60px;
+}
+
+#show-settings {
+	background-image: url(img/gear.png);
+	background-repeat: no-repeat;
+	background-size: contain;
+	width: 50px;
+
+	position: absolute;
+	right: 0px;
+}
+
 ul {
 	list-style-type: none;
 	margin: 0;
@@ -248,6 +263,48 @@ ul {
 	border-radius: 5px;
 }
 
+#resources-dialog {
+	display: none;
+
+	position: absolute;
+	width: 500px;
+	height: 400px;
+	top: 45px;
+	left: 200px;
+	z-index: 100;
+	padding: 5px;
+
+	background-color: rgba(255, 255, 255, 0.9);
+	border: 3px solid #444;
+	border-radius: 5px;
+}
+
+#close-resources {
+	position: absolute;
+	bottom: 15px;
+}
+
+#settings-dialog {
+	display: none;
+
+	position: absolute;
+	width: 500px;
+	height: 400px;
+	top: 45px;
+	left: 200px;
+	z-index: 100;
+	padding: 5px;
+
+	background-color: rgba(255, 255, 255, 0.9);
+	border: 3px solid #444;
+	border-radius: 5px;
+}
+
+#close-settings {
+	position: absolute;
+	bottom: 15px;
+}
+
 .lobby-element {
 	background-color: rgba(255, 255, 255, 0.2);
 }
@@ -317,16 +374,10 @@ ul {
 	width: 150px
 }
 
-#donation {
-	display: inline-block;
-	position: absolute;
-	right: 5px;
-}
-
 #show-options {
     position: relative;
     bottom: 2px;
-    width: 100px;
+    width: 200px;
     font-size: 21px;
 }
 

--- a/src/lobby.js
+++ b/src/lobby.js
@@ -144,6 +144,12 @@ function HanabiLobby() {
         chrome.runtime.sendMessage(extensionId, {action: "open-options"});
     });
 
+	// Hide the settings related to sending turn sounds.
+	// Those are sent from a different ui implementation.
+	var turnNotificationsOptions = $("#send-turn-sound").parents().eq(2);
+	turnNotificationsOptions.siblings().eq(1).remove();
+	turnNotificationsOptions.remove();
+
 	var logoutButton = document.createElement("button");
     logoutButton.id = "logout";
     logoutButton.innerHTML = "Log Out";

--- a/src/lobby.js
+++ b/src/lobby.js
@@ -11,8 +11,12 @@ function HanabiLobby() {
 	this.username = null;
 	this.pass = null;
 
-	this.joined_table = false;
 	this.game_id = null;
+	this.send_turn_notify = false;
+	this.send_turn_sound = false;
+	this.send_chat_notify = false;
+	this.send_chat_sound = false;
+
 	this.game = {
 		name: "",
 		num_players: 0,
@@ -24,6 +28,8 @@ function HanabiLobby() {
 	this.hide_lobby();
 	this.hide_create_dialog();
 	this.show_login();
+
+	this.load_settings();
 
 	$("#login-button").on("click", function(evt) {
 		evt.preventDefault();
@@ -67,12 +73,29 @@ function HanabiLobby() {
 		var game_name = $("#create-game-name").val();
 		var max_players = parseInt($("#create-game-players").val());
 		var variant = parseInt($("#create-game-variant").val());
+		var allow_spec = document.getElementById("create-game-allow-spec").checked;
 
 		evt.preventDefault();
 
-		self.send_msg({type: "create_table", resp: {name: game_name, max: max_players, variant: variant}});
+		self.send_msg({type: "create_table", resp: {name: game_name, max: max_players, variant: variant, allow_spec: allow_spec}});
 
 		self.hide_create_dialog();
+	});
+
+	$("#show-resources").on("click", function(evt) {
+		self.show_resources();
+	});
+
+	$("#close-resources").on("click", function(evt) {
+		self.hide_resources();
+	});
+
+	$("#show-settings").on("click", function(evt) {
+		self.show_settings();
+	});
+
+	$("#close-settings").on("click", function(evt) {
+		self.hide_settings();
 	});
 
 	$("#create-game-cancel").on("click", function(evt) {
@@ -111,13 +134,11 @@ function HanabiLobby() {
 		self.draw_history();
 	});
 
-    var optionsArea = $("#show-history").parent();
-
     var optionsButton = document.createElement("button");
     optionsButton.id = "show-options";
-    optionsButton.innerHTML = "Options";
+    optionsButton.innerHTML = "Extension Options";
 
-	optionsArea.append(optionsButton);
+	$("#settings-dialog").append(optionsButton);
     $("#show-options").on("click", function(evt) {
         evt.preventDefault();
         chrome.runtime.sendMessage(extensionId, {action: "open-options"});
@@ -127,7 +148,7 @@ function HanabiLobby() {
     logoutButton.id = "logout";
     logoutButton.innerHTML = "Log Out";
 
-    optionsArea.append(logoutButton);
+    $("#show-history").parent().append(logoutButton);
     $("#logout").on("click", function(evt) {
         deleteCookie("hanabiuser");
         deleteCookie("hanabipass");
@@ -152,6 +173,15 @@ function HanabiLobby() {
 
 	$("body").on("contextmenu", "#game", function(e) { return false; });
 }
+
+HanabiLobby.prototype.reset_lobby = function() {
+	this.user_list = {};
+	this.table_list = {};
+	this.history_list = {};
+	this.history_detail_list = [];
+	this.draw_users();
+	this.draw_tables();
+};
 
 HanabiLobby.prototype.send_login = function() {
 	$("#login-container").hide();
@@ -196,6 +226,22 @@ HanabiLobby.prototype.show_create_dialog = function() {
 
 HanabiLobby.prototype.hide_create_dialog = function() {
 	$("#create-table-dialog").fadeOut(800);
+};
+
+HanabiLobby.prototype.show_resources = function() {
+	$("#resources-dialog").fadeIn(800);
+};
+
+HanabiLobby.prototype.hide_resources = function() {
+	$("#resources-dialog").fadeOut(800);
+};
+
+HanabiLobby.prototype.show_settings = function() {
+	$("#settings-dialog").fadeIn(800);
+};
+
+HanabiLobby.prototype.hide_settings = function() {
+	$("#settings-dialog").fadeOut(800);
 };
 
 HanabiLobby.prototype.show_history_details = function() {
@@ -260,7 +306,7 @@ HanabiLobby.prototype.draw_users = function() {
 };
 
 HanabiLobby.prototype.add_table = function(data) {
-	this.table_list[data.id] = {name: data.name, num_players: data.num_players, max_players: data.max_players, variant: data.variant, joined: data.joined, running: data.running, our_turn: data.our_turn, owned: data.owned};
+	this.table_list[data.id] = {name: data.name, num_players: data.num_players, max_players: data.max_players, variant: data.variant, joined: data.joined, allow_spec: data.allow_spec, running: data.running, our_turn: data.our_turn, owned: data.owned};
 	this.draw_tables();
 };
 
@@ -296,7 +342,11 @@ HanabiLobby.prototype.draw_tables = function() {
 
 		turn = "Not Started";
 
-		if (this.table_list[i].running)
+		if (this.table_list[i].running && !this.table_list[i].joined)
+		{
+			turn = "Running";
+		}
+		else if (this.table_list[i].running)
 		{
 			if (this.table_list[i].our_turn)
 			{
@@ -310,12 +360,27 @@ HanabiLobby.prototype.draw_tables = function() {
 
 		attrs.append($("<li>").html(turn).addClass("table-attr table-turn"));
 
-		if (!this.table_list[i].joined)
+		if (!this.table_list[i].joined && this.table_list[i].allow_spec && this.table_list[i].running)
+		{
+			button = $("<button>").text("Spectate").attr("type", "button");
+			button.attr("id", "spectate-" + i);
+
+			button.on("click", function(evt) {
+				evt.preventDefault();
+
+				var id = parseInt(this.id.slice(9));
+
+				self.send_msg({type: "spectate_table", resp: {table_id: id}});
+
+				self.draw_tables();
+			});
+		}
+		else if (!this.table_list[i].joined)
 		{
 			button = $("<button>").text("Join").attr("type", "button");
 			button.attr("id", "join-" + i);
 
-			if (this.table_list[i].num_players >= this.table_list[i].max_players || this.joined_table)
+			if (this.table_list[i].num_players >= this.table_list[i].max_players)
 			{
 				button.attr("disabled", "disabled");
 			}
@@ -327,7 +392,6 @@ HanabiLobby.prototype.draw_tables = function() {
 
 				self.send_msg({type: "join_table", resp: {table_id: self.game_id}});
 
-				self.joined_table = true;
 				self.draw_tables();
 			});
 		}
@@ -343,7 +407,6 @@ HanabiLobby.prototype.draw_tables = function() {
 
 				self.send_msg({type: "reattend_table", resp: {table_id: self.game_id}});
 
-				self.joined_table = true;
 				self.draw_tables();
 			});
 		}
@@ -397,6 +460,21 @@ HanabiLobby.prototype.add_chat = function(data) {
 	chat.finish();
 	chat.append(line);
 	chat.animate({scrollTop: chat[0].scrollHeight}, 1000);
+
+	var r = new RegExp(this.username, "i");
+
+	if (data.who && r.test(data.msg))
+	{
+		if (this.send_chat_notify)
+		{
+			this.send_notify(data.who + " mentioned you in chat", "chat");
+		}
+
+		if (this.send_chat_sound)
+		{
+			this.play_sound("chat");
+		}
+	}
 };
 
 HanabiLobby.prototype.add_history = function(data) {
@@ -516,7 +594,6 @@ HanabiLobby.prototype.draw_history_details = function() {
 };
 
 HanabiLobby.prototype.table_joined = function(data) {
-	this.joined_table = true;
 	this.draw_tables();
 
 	$("#table-area").hide();
@@ -526,7 +603,6 @@ HanabiLobby.prototype.table_joined = function(data) {
 };
 
 HanabiLobby.prototype.table_left = function(data) {
-	this.joined_table = false;
 	this.draw_tables();
 
 	$("#table-area").show();
@@ -539,6 +615,7 @@ HanabiLobby.prototype.set_game = function(data) {
 	this.game.max_players = data.max_players;
 	this.game.variant = data.variant;
 	this.game.running = data.running;
+	this.game.allow_spec = data.allow_spec;
 
 	this.game.players.length = this.game.num_players;
 
@@ -568,6 +645,8 @@ HanabiLobby.prototype.show_joined = function() {
 	html += "<p>Players: " + this.game.num_players + "/" + this.game.max_players + "</p>";
 
 	html += "<p>Variant: " + variant_names[this.game.variant] + "</p>";
+
+	html += "<p>Allow Spectators: " + (this.game.allow_spec ? "Yes" : "No") + "</p>";
 
 	$("#joined-desc").html(html);
 
@@ -647,6 +726,7 @@ HanabiLobby.prototype.listen_conn = function(conn) {
 		if (msgType == "hello")
 		{
 			self.hide_login();
+			self.reset_lobby();
 			self.show_lobby();
 		}
 
@@ -815,10 +895,96 @@ HanabiLobby.prototype.set_conn = function(conn) {
 		console.log("attempting to reconnect");
 		if (self.username && self.pass) self.send_login();
 	});
+
+	window.onerror = function(message, url, lineno, colno, error) {
+		try
+		{
+			conn.emit("clienterror", {
+				message: message,
+				url: url,
+				lineno: lineno,
+				colno: colno,
+				stack: error.stack,
+				/*
+				 * ATTENTION EXTENSION AUTHORS:
+				 *
+				 * Please change "modified" to true so that
+				 * I won't chase down errors that may not
+				 * exist in my code.
+				 */
+				modified: true
+			});
+		}
+		catch (e)
+		{
+		}
+	};
 };
 
 HanabiLobby.prototype.send_msg = function(msg) {
 	this.conn.emit("message", msg);
+};
+
+HanabiLobby.prototype.load_settings = function() {
+	var self = this;
+	var settings_list = [
+		[ "send-turn-notification", "send_turn_notify" ],
+		[ "send-turn-sound", "send_turn_sound" ],
+		[ "send-chat-notification", "send_chat_notify" ],
+		[ "send-chat-sound", "send_chat_sound" ]
+	];
+	var i, val;
+
+	for (i = 0; i < settings_list.length; i++)
+	{
+		val = localStorage[settings_list[i][1]];
+		if (val !== undefined)
+		{
+			val = (val == "true");
+			$("#" + settings_list[i][0]).attr("checked", val);
+			this[settings_list[i][1]] = val;
+		}
+
+		$("#" + settings_list[i][0]).change(function() {
+			var name = $(this).attr("id");
+			var i;
+
+			for (i = 0; i < settings_list.length; i++)
+			{
+				if (settings_list[i][0] == name)
+				{
+					self[settings_list[i][1]] = $(this).is(":checked");
+					localStorage[settings_list[i][1]] = $(this).is(":checked");
+				}
+			}
+
+			if (self.send_turn_notify || self.send_chat_notify)
+			{
+				self.test_notifications();
+			}
+		});
+	}
+};
+
+HanabiLobby.prototype.test_notifications = function() {
+	if (!("Notification" in window)) return;
+
+	if (Notification.permission !== "default") return;
+
+	Notification.requestPermission();
+};
+
+HanabiLobby.prototype.send_notify = function(msg, tag) {
+	if (!("Notification" in window)) return;
+
+	if (Notification.permission !== "granted") return;
+
+	var n = new Notification("Hanabi: " + msg, { tag: tag });
+};
+
+HanabiLobby.prototype.play_sound = function(name) {
+	var a = new Audio("sounds/" + name + ".mp3");
+	a.play();
 };
 
 function getCookie(name)


### PR DESCRIPTION
Update lobby with resources and settings buttons.
Move extension settings to the settings popup.
Merge optional desktop notifications, sounds for lobby chat.
Support creating games that can be spectated.
Support spectating games.

Hide default settings not currently respected by the extension ui.js

Current settings appearance:

![settings_dialog](https://cloud.githubusercontent.com/assets/5349111/20861936/2d8be108-b952-11e6-89d8-91f21a674163.png)