### PR TITLE
Create an option that hides the exit replay button near the controls

### DIFF
--- a/extension/inject.js
+++ b/extension/inject.js
@@ -23,6 +23,7 @@ var defined_options =
     "MHGA_show_debug_messages": false,
     "MHGA_show_log_numbers": true,
     "MHGA_colorblind_mode": false,
+    "MHGA_show_exitreplay_center" : true,
     "MHGA_show_faces_in_replay": true
 }
 

--- a/extension/options.html
+++ b/extension/options.html
@@ -47,6 +47,10 @@
 <label>
     <input type="checkbox" id="MHGA_show_faces_in_replay">
     Show card faces based on your current knowledge when you use in-game rewind.
+</label><br><hr>
+<label>
+    <input type="checkbox" id="MHGA_show_exitreplay_center">
+    Show the exit replay button near the replay controls.
 </label>
 <br><hr>
 <label>

--- a/extension/options.js
+++ b/extension/options.js
@@ -9,6 +9,7 @@ var defined_options =
     "MHGA_show_debug_messages": false,
     "MHGA_show_log_numbers": true,
     "MHGA_colorblind_mode": false,
+    "MHGA_show_exitreplay_center" : true,
     "MHGA_show_faces_in_replay": true
 }
 

--- a/extension/template.txt
+++ b/extension/template.txt
@@ -8,6 +8,7 @@ var MHGA_show_debug_messages = document.getElementById("MHGA_show_debug_messages
 var MHGA_show_log_numbers = document.getElementById("MHGA_show_log_numbers").checked;
 var MHGA_colorblind_mode = document.getElementById("MHGA_colorblind_mode").checked;
 var MHGA_show_faces_in_replay = document.getElementById("MHGA_show_faces_in_replay").checked;
+var MHGA_show_exitreplay_center = document.getElementById("MHGA_show_exitreplay_center").checked;
 
 var extensionId = "pjncmjjlphlcfkkkceidbepggnjnnkjj";
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -2935,7 +2935,10 @@ this.build_ui = function() {
 		}
 	});
 
-	replay_area.add(button);
+	if (MHGA_show_exitreplay_center)
+	{
+		replay_area.add(button);
+	}
 
 	replay_area.hide();
 	uilayer.add(replay_area);


### PR DESCRIPTION
Users sometimes click out of replays by accident with the central exit replay button. An option now allows the user to remove this button. The user experience is not degraded since there is already a fixed button for returning to the lobby and a dynamic button for returning to the present moment in a game.

Screenshot demonstrating the new behavior in a replay:
![image](https://user-images.githubusercontent.com/5349111/27671175-e1964ee4-5c46-11e7-8a43-4e43fc6a1075.png)

Testing still underway.