### PR TITLE
Play sound when a game ends by deck or strikes

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -3705,6 +3705,9 @@ this.handle_notify = function(note, performing_replay) {
 
 	else if (type == "game_over")
 	{
+		if (!this.replay_only && !ui.spectating && MHGA_beep_notifications) {
+			chrome.runtime.sendMessage(extensionId, {action: "make-beep"});
+		}
 		this.replay_only = true;
 		replay_button.hide();
 		if (!this.replay) this.enter_replay(true);


### PR DESCRIPTION
A sound should play when the game ends. This is particularly useful when the game ends unexpectedly.

This does not play for spectators.

This only plays when the game ends, not when viewing the end of the game in a replay.