### PR TITLE
Improve mouseover behavior on state changes

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -582,6 +582,9 @@ HanabiCard.prototype.add_listeners = function() {
 	            self.note_given.show();
 	        } else {
 	            self.note_given.hide();
+	            self.tooltip.hide();
+	            tiplayer.draw();
+	            uilayer.draw();
 	        }
 	        cardlayer.draw();
 	    }

--- a/src/ui.js
+++ b/src/ui.js
@@ -28,6 +28,7 @@ this.ready = false;
 //in replays, we can show a grayed-out version of a card face if it was not known at the time, but we know it now.
 //these are cards we have "learned"
 this.learned_cards = [];
+this.activeHover = null;
 
 function image_name(card) {
     if(!card.unknown) {
@@ -530,6 +531,7 @@ var HanabiCard = function(config) {
             self.tooltip.show();
             tiplayer.draw();
         }
+        ui.activeHover = this;
     })
 
     this.on("mouseout", function() {
@@ -1452,6 +1454,7 @@ var HanabiClueEntry = function(config) {
 		}
 
 		cardlayer.batchDraw();
+		ui.activeHover = this;
 	});
 
 	background.on("mouseout", function() {
@@ -3406,6 +3409,13 @@ this.handle_notify = function(note, performing_replay) {
 	if(MHGA_show_debug_messages) {
         console.log(note);
     }
+
+	if (ui.activeHover)
+	{
+		ui.activeHover.dispatchEvent(new MouseEvent("mouseout"));
+		ui.activeHover = null;
+	}
+
 	if (type == "draw")
 	{
 		ui.deck[note.order] = new HanabiCard({

--- a/src/ui.js
+++ b/src/ui.js
@@ -560,7 +560,7 @@ HanabiCard.prototype.reset = function() {
 HanabiCard.prototype.add_listeners = function() {
 	var self = this;
 
-	this.on("mouseover tap", function() {
+	this.on("mousemove tap", function() {
 		clue_log.showMatches(self);
 		uilayer.draw();
 	});
@@ -1429,7 +1429,7 @@ var HanabiClueEntry = function(config) {
 	this.list = config.list;
 	this.neglist = config.neglist;
 
-	background.on("mouseover tap", function() {
+	background.on("mousemove tap", function() {
 		var i;
 
 		clue_log.showMatches(null);


### PR DESCRIPTION
- Note removal is reflected immediately, not when moving the mouse off the card.
- Whenever the displayed game state changes, either because another player took a turn or because of navigation in the replay, all hover state is explicitly cleared.
  - This ensures that the notes, outlines, and highlights do not reflect a card other than the one under the cursor.
  - When viewing an in-game replay, incoming server messages about the current state of the game do *not* trigger this behavior.
  - Forcing a redraw for the element currently hovered over, if any, is not part of these changes.
- Any mouse motion over a hovered object activates its hover behavior. This ensures that the user does not need to move the mouse off and then back over the element.